### PR TITLE
Added Error Handling for Dividing by Zero

### DIFF
--- a/.project
+++ b/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1730486179290</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,6 +3,7 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        // Error if divide by zero
         if (b == 0) {
             throw new IllegalArgumentException("/ by zero");
         }
@@ -11,6 +12,11 @@ public class Division {
     }
 
     public static final long divisionUsingLoop(int a, int b) {
+        // Error if divide by zero
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
+
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -25,6 +31,7 @@ public class Division {
     }
 
     public static final long divisionUsingRecursion(int a, int b) {
+        // Error if divide by zero
         if (b == 0) {
             throw new IllegalArgumentException("/ by zero");
         }
@@ -44,6 +51,7 @@ public class Division {
     }
 
     public static final long divisionUsingMultiplication(int a, int b) {
+        // Error if divide by zero
         if (b == 0) {
             throw new IllegalArgumentException("/ by zero");
         }
@@ -64,6 +72,7 @@ public class Division {
     }
 
     public static final long divisionUsingShift(int a, int b) {
+        // Error if divide by zero
         if (b == 0) {
             throw new IllegalArgumentException("/ by zero");
         }
@@ -88,6 +97,7 @@ public class Division {
     }
 
     public static final long divisionUsingLogs(int a, int b) {
+        // Error if divide by zero
         if (b == 0) {
             throw new IllegalArgumentException("/ by zero");
         }

--- a/src/com/jwetherell/algorithms/mathematics/Division.java
+++ b/src/com/jwetherell/algorithms/mathematics/Division.java
@@ -3,6 +3,9 @@ package com.jwetherell.algorithms.mathematics;
 public class Division {
 
     public static final long division(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
         long result = ((long) a) / ((long) b);
         return result;
     }
@@ -22,6 +25,9 @@ public class Division {
     }
 
     public static final long divisionUsingRecursion(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -38,6 +44,9 @@ public class Division {
     }
 
     public static final long divisionUsingMultiplication(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
 
@@ -55,6 +64,9 @@ public class Division {
     }
 
     public static final long divisionUsingShift(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
         int absA = Math.abs(a);
         int absB = Math.abs(b);
         int tempA, tempB, counter;
@@ -76,6 +88,9 @@ public class Division {
     }
 
     public static final long divisionUsingLogs(int a, int b) {
+        if (b == 0) {
+            throw new IllegalArgumentException("/ by zero");
+        }
         long absA = Math.abs(a);
         long absB = Math.abs(b);
         double logBase10A = Math.log10(absA);


### PR DESCRIPTION
Added Error Handling for Dividing by Zero by adding an if statement at the beginning of each method that checks if the divisor is equal to 0. If this is true, a IllegalArgumentException will be thrown with the error message "/ by zero". This will help in identifying bugs when the divisor is set to 0 unintentionally. It also will prevent unexpected crashes or behaviour.